### PR TITLE
bump Elephas version to latest (i.e. 1.4.2)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "elephas" %}
-{% set version = "0.4.3" %}
+{% set version = "1.4.2" %}
 
 package:
   name: {{ name|lower }}
@@ -26,7 +26,8 @@ requirements:
     - pyspark
     - tensorflow
     - python >=3
-    - six
+    - h5py
+
 
 test:
   imports:


### PR DESCRIPTION
This should be a fairly straightforward version bump. 

Fixed the package version, 
Fixed the dependencies,
Left the build number at 0, 
Should not require re-rendering. 


